### PR TITLE
fix: use scan.targetFileName as part of issue id

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.snyk.integrations.fortify</groupId>
     <artifactId>parser</artifactId>
-    <version>0.0.2</version>
+    <version>0.0.3</version>
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/src/main/java/io/snyk/integrations/fortify/parser/CustomAttribute.java
+++ b/src/main/java/io/snyk/integrations/fortify/parser/CustomAttribute.java
@@ -14,7 +14,7 @@ public enum CustomAttribute implements com.fortify.plugin.spi.VulnerabilityAttri
     FROM("from", AttrType.STRING),
     IS_UPGRADABLE("isUpgradable", AttrType.STRING),
     IS_PATCHABLE("isPatchable", AttrType.STRING),
-    FILENAME("filename", AttrType.STRING),
+    TARGET_FILE("targetFile", AttrType.STRING),
     ISSUE_URL("issueUrl", AttrType.STRING);
     ;
 

--- a/src/main/java/io/snyk/integrations/fortify/parser/Scan.java
+++ b/src/main/java/io/snyk/integrations/fortify/parser/Scan.java
@@ -4,28 +4,10 @@ import java.util.Date;
 
 public class Scan {
     public Date scanDate;
+
+    public String displayTargetFile;
     
     public Issue[] vulnerabilities;
-
-    // ignored
-    // public boolean ok;
-    // public String packageManager;
-    // public String policy;
-    // public String summary;
-    // public int uniqueCount;
-    // public String path;
-    // public int dependencyCount;
-    // public String org;
-    // public ? licensesPolicy;
-    // public boolean isPrivate;
-    // public ? ignoreSettings;
-    // public Filtered filtered;
-    // public boolean filesystemPolicy;
-
-    // public class Filtered {
-    //     public String[] ignore;
-    //     public String[] patch;
-    // };
 
     public class Issue {
         public String id;
@@ -41,41 +23,5 @@ public class Scan {
 
         public boolean isUpgradable;
         public boolean isPatchable;
-        public String __filename;
-        // ignored
-        // public String packageName;
-        // public Semver semver;
-        // public ?[] upgradePath;
-        // public String creationTime;
-        // public String parentDepType;
-
-        // vulnerability only
-        // public double cvssScore;
-        // public String CVSSv3;
-        // public String[] credit;
-        // public String moduleName;
-        // public String modificationTime;
-        // public String disclosureTime;
-        // public String[] alternativeIds;
-        // public Patch[] patches;
-        // public ?[] identifiers
-
-        // license only
-        // public String license;
-        // public String type;
-        // public String licenseTemplateUrl;
-
-        // public class Semver {
-        //     public String[] vulnerable;
-        //     public String[] unaffected;
-        // }
-
-        // public class Patch {
-        //     public String[] urls;
-        //     public String vestions;
-        //     public String modificationTime;
-        //     public String[] comments;
-        //     public String id;
-        // }
     }
 }

--- a/src/main/java/io/snyk/integrations/fortify/parser/SnykParserPlugin.java
+++ b/src/main/java/io/snyk/integrations/fortify/parser/SnykParserPlugin.java
@@ -74,11 +74,11 @@ public class SnykParserPlugin implements ParserPlugin<CustomAttribute> {
             for (Scan scan : scans) {
                 for (Scan.Issue issue : scan.vulnerabilities) {
                     try {
-                        String uniqueId = hashJsonObject(issue);
+                        String uniqueId = scan.displayTargetFile + ":" + hashJsonObject(issue);
                         StaticVulnerabilityBuilder vulnerabilityBuilder = vulnerabilityHandler
                                 .startStaticVulnerability(uniqueId);
 
-                        buildVulnerability(vulnerabilityBuilder, issue);
+                        buildVulnerability(vulnerabilityBuilder, issue, scan.displayTargetFile);
 
                         vulnerabilityBuilder.completeVulnerability();
                     } catch (NullPointerException e) {
@@ -91,7 +91,7 @@ public class SnykParserPlugin implements ParserPlugin<CustomAttribute> {
         }
     }
 
-    private void buildVulnerability(final StaticVulnerabilityBuilder vulnerabilityBuilder, final Scan.Issue issue) {
+    private void buildVulnerability(final StaticVulnerabilityBuilder vulnerabilityBuilder, final Scan.Issue issue, final String targetFile) {
         // mandatory by SSC
         vulnerabilityBuilder.setAccuracy(5f);
         vulnerabilityBuilder.setAnalyzer("snyk");
@@ -117,11 +117,6 @@ public class SnykParserPlugin implements ParserPlugin<CustomAttribute> {
         vulnerabilityBuilder.setProbability(5f);
         vulnerabilityBuilder.setCategory(issue.title);
 
-        // optional
-        // vulnerabilityBuilder.setVulnerabilityAbstract(issue.description);
-        // vulnerabilityBuilder.setVulnerabilityRecommendation("fixed on snyk.io");
-        // vulnerabilityBuilder.setPackageName(issue.name);
-        // vulnerabilityBuilder.setFileName(issue.__filename);
         vulnerabilityBuilder.setFileName(issue.from[issue.from.length - 1]);
 
         // custom
@@ -139,7 +134,7 @@ public class SnykParserPlugin implements ParserPlugin<CustomAttribute> {
                 (issue.isUpgradable ? "Yes" : "No"));
         vulnerabilityBuilder.setStringCustomAttributeValue(CustomAttribute.IS_PATCHABLE,
                 (issue.isPatchable ? "Yes" : "No"));
-        vulnerabilityBuilder.setStringCustomAttributeValue(CustomAttribute.FILENAME, issue.__filename);
+        vulnerabilityBuilder.setStringCustomAttributeValue(CustomAttribute.TARGET_FILE, targetFile);
         vulnerabilityBuilder.setStringCustomAttributeValue(CustomAttribute.ISSUE_URL,
                 "https://snyk.io/vuln/" + issue.id);
     }

--- a/src/main/resources/plugin.xml
+++ b/src/main/resources/plugin.xml
@@ -4,7 +4,7 @@
         id="io.snyk.integrations.fortify.parser" api-version="1.0">
     <plugin-info>
         <name>Snyk Parser Plugin</name>
-        <version><!--VERSION-->0.0.2<!--/VERSION--></version>
+        <version><!--VERSION-->0.0.3<!--/VERSION--></version>
         <data-version>1</data-version>
         <vendor name="Snyk" url="https://snyk.io"/>
         <description>Snyk automates finding and fixing known vulnerabilities in your open source dependencies. This plugin parses "snyk test" results and uploads them to Fortify Software Security Center.

--- a/src/main/resources/resources/en.properties
+++ b/src/main/resources/resources/en.properties
@@ -10,5 +10,5 @@ publicationTime=Publication Time
 from=Through
 isUpgradable=Is Upgradable
 isPatchable=Is Patchable
-filename=Filename
+targetFile=Target File
 issueUrl=More Info on snyk.io

--- a/src/main/resources/viewtemplate/ViewTemplate.json
+++ b/src/main/resources/viewtemplate/ViewTemplate.json
@@ -51,7 +51,7 @@
         },
         {
           "type": "template",
-          "key": "customAttributes.filename",
+          "key": "customAttributes.targetFile",
           "templateId": "SIMPLE",
           "dataType": "string"
         },


### PR DESCRIPTION
As per Fortify SSC specification, each issue should have a unique id across the whole scan. Because for multi-module projects, the exact same issue can appear under multiple modules - there might be a collision.
The solution was to use the filed `displayTargetFile` from the scan object, and prepend it to the existing unique issue id (hash of the issue json).

Also added a `Target File` field to the custom issue display, for convenience.